### PR TITLE
Add Authenticode signing for EXE and MSI installers

### DIFF
--- a/.github/scripts/sign-exe.ps1
+++ b/.github/scripts/sign-exe.ps1
@@ -1,0 +1,124 @@
+<#
+  sign-exe.ps1
+  Sign a Windows binary (.exe or .msi) with Certum certificate via signtool
+#>
+
+param(
+    [Parameter(Mandatory=$true)]
+    [string]$BinaryPath,
+
+    [string]$CertificateSHA1 = $env:CERTUM_CERTIFICATE_SHA1
+)
+
+if (-not $CertificateSHA1) {
+    Write-Host "ERROR: CERTUM_CERTIFICATE_SHA1 not set"
+    exit 1
+}
+
+if (-not (Test-Path $BinaryPath)) {
+    Write-Host "ERROR: Binary not found: $BinaryPath"
+    exit 1
+}
+
+Write-Host "=== Signing Windows Binary ==="
+Write-Host "Binary: $BinaryPath"
+Write-Host "Certificate SHA1: $($CertificateSHA1.Substring(0, [Math]::Min(16, $CertificateSHA1.Length)))..."
+
+# Locate signtool.exe dynamically
+$SignTool = $null
+
+# Search all installed Windows SDK versions
+$sdkBinRoot = "${env:ProgramFiles(x86)}\Windows Kits\10\bin"
+if (Test-Path $sdkBinRoot) {
+    $found = Get-ChildItem -Path $sdkBinRoot -Filter "signtool.exe" -Recurse -ErrorAction SilentlyContinue |
+        Where-Object { $_.FullName -match '\\x64\\' } |
+        Sort-Object { $_.Directory.Parent.Name } -Descending |
+        Select-Object -First 1
+    if ($found) {
+        $SignTool = $found.FullName
+    }
+}
+
+if (-not $SignTool) {
+    # Try finding it via PATH
+    $SignTool = (Get-Command signtool.exe -ErrorAction SilentlyContinue).Source
+}
+
+if (-not $SignTool) {
+    Write-Host "ERROR: signtool.exe not found"
+    Write-Host "Searched: $sdkBinRoot"
+    if (Test-Path $sdkBinRoot) {
+        Write-Host "Available SDK versions:"
+        Get-ChildItem -Path $sdkBinRoot -Directory | ForEach-Object { Write-Host "  $_" }
+    }
+    exit 1
+}
+
+Write-Host "Using signtool: $SignTool"
+
+# List available certificates for diagnostics
+Write-Host ""
+Write-Host "Checking certificate stores..."
+$stores = @("CurrentUser\My", "LocalMachine\My")
+foreach ($storeName in $stores) {
+    $parts = $storeName -split '\\'
+    $location = $parts[0]
+    $name = $parts[1]
+    $store = New-Object System.Security.Cryptography.X509Certificates.X509Store($name, $location)
+    try {
+        $store.Open("ReadOnly")
+        $certs = $store.Certificates
+        Write-Host "  ${storeName}: $($certs.Count) certificate(s)"
+        foreach ($cert in $certs) {
+            Write-Host "    - $($cert.Thumbprint) | $($cert.Subject) | Issuer: $($cert.Issuer)"
+        }
+        $store.Close()
+    } catch {
+        Write-Host "  ${storeName}: Could not open store - $_"
+    }
+}
+
+# Sign with retry - certificate may take time to appear
+Write-Host ""
+Write-Host "Signing with retry..."
+$signExit = 1
+$maxAttempts = 6
+for ($attempt = 1; $attempt -le $maxAttempts; $attempt++) {
+    Write-Host ""
+    Write-Host "Attempt $attempt of $maxAttempts..."
+    $signOutput = & $SignTool sign /sha1 $CertificateSHA1 /tr "http://time.certum.pl" /td SHA256 /fd SHA256 /v $BinaryPath 2>&1
+    $signExit = $LASTEXITCODE
+    Write-Host $signOutput
+
+    if ($signExit -eq 0) {
+        Write-Host "Signing succeeded on attempt $attempt"
+        break
+    }
+
+    if ($attempt -lt $maxAttempts) {
+        Write-Host "Signing failed, waiting 10 seconds before retry..."
+        Start-Sleep -Seconds 10
+    }
+}
+
+if ($signExit -ne 0) {
+    Write-Host "ERROR: Signing failed after $maxAttempts attempts (exit code $signExit)"
+    exit 1
+}
+
+Write-Host ""
+Write-Host "Verifying signature..."
+$verifyOutput = & $SignTool verify /pa /v $BinaryPath 2>&1
+$verifyExit = $LASTEXITCODE
+
+Write-Host $verifyOutput
+
+if ($verifyExit -ne 0) {
+    Write-Host "WARNING: Signature verification failed (exit code $verifyExit)"
+    Write-Host "The binary may still be signed - verification can fail in CI without full cert chain"
+} else {
+    Write-Host "SUCCESS: Signature verified"
+}
+
+Write-Host ""
+Write-Host "=== Signing complete ==="

--- a/.github/workflows/ant-latest.yml
+++ b/.github/workflows/ant-latest.yml
@@ -86,6 +86,81 @@ jobs:
           name: I2P-MSI-unsigned-jdk22.msi
           path: I2P-MSI-*.msi
 
+  sign-nsis-jdk22:
+    needs: nsis-jdk22
+    runs-on: [self-hosted, Windows, X64]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          sparse-checkout: .github/scripts
+          sparse-checkout-cone-mode: false
+      - name: Download unsigned NSIS installer
+        uses: actions/download-artifact@v4
+        with:
+          name: I2P-Easy-Install-Bundle-unsigned-jdk22.exe
+      - name: Sign NSIS installer
+        env:
+          CERTUM_CERTIFICATE_SHA1: ${{ secrets.CERTUM_CERTIFICATE_SHA1 }}
+        run: |
+          $exe = Get-ChildItem -Filter "I2P-Easy-Install-Bundle-*.exe" | Select-Object -First 1
+          powershell -ExecutionPolicy Bypass -File ".github/scripts/sign-exe.ps1" -BinaryPath $exe.FullName
+        shell: powershell
+      - name: Upload signed NSIS installer
+        uses: actions/upload-artifact@v4
+        with:
+          name: I2P-Easy-Install-Bundle-signed-jdk22.exe
+          path: I2P-Easy-Install-Bundle-*.exe
+
+  sign-exe-jdk22:
+    needs: buildjpackagexe-jdk22
+    runs-on: [self-hosted, Windows, X64]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          sparse-checkout: .github/scripts
+          sparse-checkout-cone-mode: false
+      - name: Download unsigned EXE installer
+        uses: actions/download-artifact@v4
+        with:
+          name: I2P-EXE-unsigned-jdk22.exe
+      - name: Sign EXE installer
+        env:
+          CERTUM_CERTIFICATE_SHA1: ${{ secrets.CERTUM_CERTIFICATE_SHA1 }}
+        run: |
+          $exe = Get-ChildItem -Filter "I2P-EXE-*.exe" | Select-Object -First 1
+          powershell -ExecutionPolicy Bypass -File ".github/scripts/sign-exe.ps1" -BinaryPath $exe.FullName
+        shell: powershell
+      - name: Upload signed EXE installer
+        uses: actions/upload-artifact@v4
+        with:
+          name: I2P-EXE-signed-jdk22.exe
+          path: I2P-EXE-*.exe
+
+  sign-msi-jdk22:
+    needs: buildjpackagmsi-jdk22
+    runs-on: [self-hosted, Windows, X64]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          sparse-checkout: .github/scripts
+          sparse-checkout-cone-mode: false
+      - name: Download unsigned MSI installer
+        uses: actions/download-artifact@v4
+        with:
+          name: I2P-MSI-unsigned-jdk22.msi
+      - name: Sign MSI installer
+        env:
+          CERTUM_CERTIFICATE_SHA1: ${{ secrets.CERTUM_CERTIFICATE_SHA1 }}
+        run: |
+          $msi = Get-ChildItem -Filter "I2P-MSI-*.msi" | Select-Object -First 1
+          powershell -ExecutionPolicy Bypass -File ".github/scripts/sign-exe.ps1" -BinaryPath $msi.FullName
+        shell: powershell
+      - name: Upload signed MSI installer
+        uses: actions/upload-artifact@v4
+        with:
+          name: I2P-MSI-signed-jdk22.msi
+          path: I2P-MSI-*.msi
+
   buildzip-jdk22:
     runs-on: windows-latest
     steps:

--- a/.github/workflows/ant.yml
+++ b/.github/workflows/ant.yml
@@ -86,6 +86,81 @@ jobs:
           name: I2P-MSI-unsigned.msi
           path: I2P-MSI-*.msi
 
+  sign-nsis:
+    needs: nsis
+    runs-on: [self-hosted, Windows, X64]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          sparse-checkout: .github/scripts
+          sparse-checkout-cone-mode: false
+      - name: Download unsigned NSIS installer
+        uses: actions/download-artifact@v4
+        with:
+          name: I2P-Easy-Install-Bundle-unsigned.exe
+      - name: Sign NSIS installer
+        env:
+          CERTUM_CERTIFICATE_SHA1: ${{ secrets.CERTUM_CERTIFICATE_SHA1 }}
+        run: |
+          $exe = Get-ChildItem -Filter "I2P-Easy-Install-Bundle-*.exe" | Select-Object -First 1
+          powershell -ExecutionPolicy Bypass -File ".github/scripts/sign-exe.ps1" -BinaryPath $exe.FullName
+        shell: powershell
+      - name: Upload signed NSIS installer
+        uses: actions/upload-artifact@v4
+        with:
+          name: I2P-Easy-Install-Bundle-signed.exe
+          path: I2P-Easy-Install-Bundle-*.exe
+
+  sign-exe:
+    needs: buildjpackagexe
+    runs-on: [self-hosted, Windows, X64]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          sparse-checkout: .github/scripts
+          sparse-checkout-cone-mode: false
+      - name: Download unsigned EXE installer
+        uses: actions/download-artifact@v4
+        with:
+          name: I2P-EXE-unsigned.exe
+      - name: Sign EXE installer
+        env:
+          CERTUM_CERTIFICATE_SHA1: ${{ secrets.CERTUM_CERTIFICATE_SHA1 }}
+        run: |
+          $exe = Get-ChildItem -Filter "I2P-EXE-*.exe" | Select-Object -First 1
+          powershell -ExecutionPolicy Bypass -File ".github/scripts/sign-exe.ps1" -BinaryPath $exe.FullName
+        shell: powershell
+      - name: Upload signed EXE installer
+        uses: actions/upload-artifact@v4
+        with:
+          name: I2P-EXE-signed.exe
+          path: I2P-EXE-*.exe
+
+  sign-msi:
+    needs: buildjpackagmsi
+    runs-on: [self-hosted, Windows, X64]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          sparse-checkout: .github/scripts
+          sparse-checkout-cone-mode: false
+      - name: Download unsigned MSI installer
+        uses: actions/download-artifact@v4
+        with:
+          name: I2P-MSI-unsigned.msi
+      - name: Sign MSI installer
+        env:
+          CERTUM_CERTIFICATE_SHA1: ${{ secrets.CERTUM_CERTIFICATE_SHA1 }}
+        run: |
+          $msi = Get-ChildItem -Filter "I2P-MSI-*.msi" | Select-Object -First 1
+          powershell -ExecutionPolicy Bypass -File ".github/scripts/sign-exe.ps1" -BinaryPath $msi.FullName
+        shell: powershell
+      - name: Upload signed MSI installer
+        uses: actions/upload-artifact@v4
+        with:
+          name: I2P-MSI-signed.msi
+          path: I2P-MSI-*.msi
+
   buildzip:
     runs-on: windows-latest
     steps:


### PR DESCRIPTION
Add sign-exe.ps1 script using signtool with Certum certificate and signing jobs to both ant.yml and ant-latest.yml workflows. Signing runs on self-hosted Windows runner after builds complete, producing signed artifacts alongside the existing unsigned ones.